### PR TITLE
Skip weight init in replace_linear_with_ramtorch() helper function

### DIFF
--- a/ramtorch/helpers.py
+++ b/ramtorch/helpers.py
@@ -196,6 +196,7 @@ def replace_linear_with_ramtorch(module: nn.Module, device: str = "cuda"):
                 bias=child.bias is not None,
                 device=device,
                 dtype=child.weight.dtype,
+                skip_init=True,
             )
 
             # Reference weights and bias

--- a/ramtorch/modules/linear.py
+++ b/ramtorch/modules/linear.py
@@ -397,6 +397,7 @@ class CPUBouncingLinear(nn.Module):
         bias=True,
         dtype=None,
         device=torch.cuda.current_device(),
+        skip_init=False,
     ):
         """
         Initialize CPU linear layer.
@@ -438,11 +439,12 @@ class CPUBouncingLinear(nn.Module):
             self.bias.is_ramtorch = True
 
         # init
-        nn.init.kaiming_uniform_(self.weight, a=5**0.5)
-        if self.bias is not None:
-            fan_in = in_features
-            bound = 1 / fan_in**0.5
-            nn.init.uniform_(self.bias, -bound, bound)
+        if not skip_init:
+            nn.init.kaiming_uniform_(self.weight, a=5**0.5)
+            if self.bias is not None:
+                fan_in = in_features
+                bound = 1 / fan_in**0.5
+                nn.init.uniform_(self.bias, -bound, bound)
 
     def _apply(self, fn):
         """


### PR DESCRIPTION
I appreciate the recent updates to add a replace helper function and fix the _apply behavior, those were both pain points I had to find kludgy workarounds for when testing before. 

One less important, but still annoying issue I found was weight init. When loading a pretrained model there is absolutely no reason to init the weights since they're just going to be overwritten anyway, and skipping this can save several minutes of cpu churn when loading a large model.

Here's a before/after test with Wan 14b:

```python
model = WanTransformer3DModel.from_pretrained("./models/Wan2.1-T2V-14B-Diffusers/transformer").to(device="cpu", dtype=torch.bfloat16)
start = perf_counter()
model = replace_linear_with_ramtorch(model, "cuda")
end = perf_counter()
print(f"ramtorch conversion time: {end - start} s")
```

before (with init): `ramtorch conversion time: 153.37886830000207 s`

after (skipped init): `ramtorch conversion time: 2.2231921998318285 s`