### PR TITLE
Accelerate and torchrun launcher support

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,17 @@ if __name__ == "__main__":
     mp.spawn(train, args=(world_size, model), nprocs=world_size)
 ```
 
+If you launch workers independently (e.g., `torchrun` or HuggingFace Accelerate), share the CPU-backed RamTorch parameters explicitly after `dist.init_process_group`:
+
+```python
+from ramtorch.helpers import attach_shared_ramtorch_parameters
+
+# after init_process_group and model construction on each rank
+attached = attach_shared_ramtorch_parameters(model)
+# If you cannot use shared memory, set include_ramtorch=True when calling
+# broadcast_zero_params(...) so RamTorch parameters still stay in sync.
+```
+
 ## Performance Considerations
 
 ### When to Use RamTorch


### PR DESCRIPTION
what & why

- make ramtorch work under torchrun/accelerate where workers don’t inherit the parent’s shared CPU tensors (no more relying on fork/vfork side-effects for sharing).
- keep ramtorch params in sync even when shared storage can’t be used.
- add a non-cuda fallback path so linear doesn’t explode on mps/cpu (still offload-less, but functions adequately for testing spawn behaviour)

change details

- new attach_shared_ramtorch_parameters(model, process_group=None): rank0 shares CPU storages, broadcasts handles, other ranks rebind their ramtorch params to the shared storage; barrier to settle. preserves single-host-copy behavior without a parent-process fork.
- broadcast_zero_params(..., include_ramtorch=False): optional sync of ramtorch params when sharing isn’t available (correctness over memory dedup).
- linear: pick device in order cuda→mps→cpu; skip pin_memory when cuda isn’t there; add synchronous fwd/bwd path for non-cuda devices.

the mps-compatible path is added so that development on ramtorch can be done even when on unified architecture.

i've got a [monkeypatch](https://github.com/bghira/SimpleTuner/pull/2027/commits/7a93fe7bdfdddbab2d136617ef632a488b0b3bdc) version of this for my trainer that patches ramtorch at runtime, so if you're not comfortable including these changes, it's not a big deal - but it would be very nice to support more broad adoption of ramtorch for multigpu/multinode training.